### PR TITLE
Add frictionless extras directly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,11 +154,11 @@ output_directory = "docs"
 legacy_tox_ini = """
 [tox]
 isolated_build = true
-envlist = py310, lint
+envlist = py311, lint
 
 [gh-actions]
 python =
-    3: py310, lint
+    3: py311, lint
 
 [testenv]
 recreate = true
@@ -170,7 +170,7 @@ commands =
     pytest --cov=hdx --no-cov-on-fail --junitxml=.tox/test-results.xml --cov-report=xml --cov-report=term-missing
 
 [testenv:lint]
-wheel_build_env = py310
+wheel_build_env = py311
 deps =
     flakeheaven
     flake8
@@ -180,14 +180,14 @@ commands =
     flakeheaven lint src tests
 
 [testenv:docs]
-wheel_build_env = py310
+wheel_build_env = py311
 deps =
     pydoc-markdown
 commands =
     pydoc-markdown
 
 [testenv:publish]
-wheel_build_env = py310
+wheel_build_env = py311
 passenv = SSH_AUTH_SOCK TWINE_USERNAME TWINE_PASSWORD
 deps =
     twine

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,20 @@ package_dir =
 
 python_requires = >=3.6
 
+# Extras for frictionless[excel,json] added explicitly
+# for conda-forge compatibility
 install_requires =
     basicauth
-    frictionless[excel,json]>=4.40.8
+    frictionless>=4.40.8
+    # frictionless[excel]
+    openpyxl>=3.0
+    tableschema-to-template>=0.0
+    xlrd>=1.2
+    xlwt>=1.2
+    # frictionless[json]
+    ijson>=3.0
+    jsonlines>=1.2
+    # /end frictionless extras
     loguru
     python-dateutil==2.8.2
     ratelimit

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     frictionless>=4.40.8
     # frictionless[excel]
     openpyxl>=3.0
-    tableschema-to-template>=0.0
+    tableschema-to-template>=0.0.12
     xlrd>=1.2
     xlwt>=1.2
     # frictionless[json]


### PR DESCRIPTION
Partially addresses #10.

I've taken the  `frictionless` v4.40.8 extras from [here](https://github.com/frictionlessdata/framework/blob/342b155747eb3b3b7588fc84a59f69a93cb9fce0/setup.py#L49-L57) and added them explicitly in `setup.cfg`