### PR TITLE
Remove requirement for tableschema

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,8 @@ install_requires =
     frictionless>=5.5.1
     # frictionless[excel]
     openpyxl>=3.0
-    tableschema-to-template>=0.0.12
+    # Removing as not explicitly needed, and not available on conda
+    # tableschema-to-template>=0.0.12
     xlrd>=1.2
     xlwt>=1.2
     # frictionless[json]


### PR DESCRIPTION
@mcarans  We want to start promoting AnticiPy soon, and it for that it would be good to have it on conda forge. This is the last blocker, do you think it would be okay to remove `tableschema-to-template`, at least temporarily? As mentioned [here](https://github.com/OCHA-DAP/hdx-python-utilities/issues/10#issuecomment-1344272733) I checked that it will not break anything. Only you will need to keep this in mind in case you ever add further `frictionless` functionality. 