### PR TITLE
Add custom configs

### DIFF
--- a/.config/black.toml
+++ b/.config/black.toml
@@ -1,0 +1,2 @@
+[tool.black]
+line-length = 79

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -1,0 +1,22 @@
+[report]
+omit =
+    "*/setup.py"
+    "*/python?.?/*"
+    "*/venv/*"
+    "*/site-packages/*"
+    "*/tests/*"
+    "*__init__*"
+
+exclude_lines =
+    "pragma: no cover"  # Have to re-enable the standard pragma
+    "def __repr__"  # Don't complain about missing
+    "if self.debug"  # debug-only code
+    "raise AssertionError"  # Don't complain if tests don't hit
+    "raise NotImplementedError"  # defensive assertion code
+    "if 0:"  # Don't complain if non-runnable code
+    "if __name__ == .__main__.:"  # isn't run
+
+[paths]
+source =
+    "src/hdx"
+    "*/site-packages/hdx"

--- a/.config/pre-commit-config.yaml
+++ b/.config/pre-commit-config.yaml
@@ -5,11 +5,12 @@ repos:
     rev: 23.3.0
     hooks:
       - id: black
+        args: [--config, .config/black.toml]
   - repo: https://github.com/charliermarsh/ruff-pre-commit
     rev: v0.0.267
     hooks:
       - id: ruff
-        args: [--fix, --exit-non-zero-on-fix]
+        args: [--config, .config/ruff.toml, --fix, --exit-non-zero-on-fix]
   - repo: https://github.com/jazzband/pip-tools
     rev: 6.13.0
     hooks:

--- a/.config/pytest.ini
+++ b/.config/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+pythonpath = "src"
+addopts = "--color=yes"
+log_cli = 1

--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -1,0 +1,14 @@
+line-length = 79
+exclude = ["_version.py"]
+ignore = [
+    "E501" # Line too long
+]
+# List of rules: https://beta.ruff.rs/docs/rules/
+select = [
+  "E",   # pycodestyle - default
+  "F",   # pyflakes - default
+  "I"    # isort
+]
+
+[isort]
+known-local-folder = ["hdx"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To check if your changes pass pre-commit without committing, run:
 
 To run the tests and view coverage, execute:
 
-    pytest --cov hdx --cov-config .config/coveragerc
+    pytest -c .config/pytest.ini --cov hdx --cov-config .config/coveragerc
 
 Follow the example set out already in ``api.rst`` as you write the documentation.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ To check if your changes pass pre-commit without committing, run:
 
 To run the tests and view coverage, execute:
 
-    python -m pytest --cov hdx
+    pytest --cov hdx --cov-config .config/coveragerc
 
 Follow the example set out already in ``api.rst`` as you write the documentation.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,61 +1,10 @@
 #########################
-# General Configuration #
+# Project Configuration #
 #########################
-
-# Build
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
-
-# Versioning
-
-[tool.hatch.version]
-source = "vcs"
-
-[tool.hatch.version.raw-options]
-local_scheme = "no-local-version"
-version_scheme = "python-simplified-semver"
-
-# Publishing
-
-[tool.hatch.publish.index]
-disable = true
-
-# Tests
-
-[tool.hatch.envs.test]
-features = ["html", "email", "test"]
-
-[tool.hatch.envs.test.scripts]
-test = 'pytest -c .config/pytest.ini --cov=hdx --cov-config=.config/coveragerc --no-cov-on-fail --junitxml=.tox/test-results.xml --cov-report=xml --cov-report=term-missing'
-
-[[tool.hatch.envs.test.matrix]]
-python = ["3.11"]
-
-[tool.hatch.envs.lint]
-detached = true
-dependencies = [
-  "black",
-  "ruff",
-]
-
-[tool.hatch.envs.lint.scripts]
-style = [
-  "ruff --config .config/ruff.toml {args:.}",
-  "black --config .config/black.toml --check --diff {args:.}",
-]
-# Not used for anything at the moment
-fmt = [
-  "black --config .config/black.toml {args:.}",
-  "ruff --config .config/ruff.toml --fix {args:.}",
-]
-
-#########################
-# Project Configuration #
-#########################
-
-# Project
 
 [project]
 name = "hdx-python-utilities"
@@ -118,6 +67,11 @@ email = ["email_validator"]
 test = ["pytest", "pytest-cov", "pytest-loguru"]
 dev = ["pre-commit"]
 
+
+#########
+# Hatch #
+#########
+
 # Build
 
 [tool.hatch.build.targets.wheel]
@@ -126,7 +80,57 @@ packages = ["src/hdx"]
 [tool.hatch.build.hooks.vcs]
 version-file = "src/hdx/utilities/_version.py"
 
-# Pydoc Markdown - will be moved
+# Versioning
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+local_scheme = "no-local-version"
+version_scheme = "python-simplified-semver"
+
+# Publishing
+
+[tool.hatch.publish.index]
+disable = true
+
+# Tests
+
+[tool.hatch.envs.test]
+features = ["html", "email", "test"]
+
+[tool.hatch.envs.test.scripts]
+test = """
+       pytest -c .config/pytest.ini --cov=hdx
+       --cov-config=.config/coveragerc --no-cov-on-fail
+       --junitxml=.tox/test-results.xml --cov-report=xml
+       --cov-report=term-missing"
+       """
+
+[[tool.hatch.envs.test.matrix]]
+python = ["3.11"]
+
+[tool.hatch.envs.lint]
+detached = true
+dependencies = [
+  "black",
+  "ruff",
+]
+
+[tool.hatch.envs.lint.scripts]
+style = [
+  "ruff --config .config/ruff.toml {args:.}",
+  "black --config .config/black.toml --check --diff {args:.}",
+]
+# Not used for anything at the moment
+fmt = [
+  "black --config .config/black.toml {args:.}",
+  "ruff --config .config/ruff.toml --fix {args:.}",
+]
+
+##################
+# PyDoc Markdown #
+##################
 
 [[tool.pydoc-markdown.loaders]]
 type = "python"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,27 +22,6 @@ version_scheme = "python-simplified-semver"
 [tool.hatch.publish.index]
 disable = true
 
-# Linting tools
-
-[tool.black]
-line-length = 79
-
-[tool.ruff]
-line-length = 79
-exclude = ["_version.py"]
-ignore = [
-    "E501" # Line too long
-]
-# List of rules: https://beta.ruff.rs/docs/rules/
-select = [
-  "E",   # pycodestyle - default
-  "F",   # pyflakes - default
-  "I"    # isort
-]
-
-[tool.ruff.isort]
-known-local-folder = ["hdx"]
-
 # Tests
 
 [tool.pytest.ini_options]
@@ -68,13 +47,13 @@ dependencies = [
 
 [tool.hatch.envs.lint.scripts]
 style = [
-  "ruff {args:.}",
-  "black --check --diff {args:.}",
+  "ruff --config .config/ruff.toml {args:.}",
+  "black --config .config/black.toml --check --diff {args:.}",
 ]
 # Not used for anything at the moment
 fmt = [
-  "black {args:.}",
-  "ruff --fix {args:.}",
+  "black --config .config/black.toml {args:.}",
+  "ruff --config .config/ruff.toml --fix {args:.}",
 ]
 
 [tool.coverage.report]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,16 +24,11 @@ disable = true
 
 # Tests
 
-[tool.pytest.ini_options]
-pythonpath = "src"
-addopts = "--color=yes"
-log_cli = 1
-
 [tool.hatch.envs.test]
 features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
-test = 'pytest --cov=hdx --cov-config=.config/coveragerc --no-cov-on-fail --junitxml=.tox/test-results.xml --cov-report=xml --cov-report=term-missing'
+test = 'pytest -c .config/pytest.ini --cov=hdx --cov-config=.config/coveragerc --no-cov-on-fail --junitxml=.tox/test-results.xml --cov-report=xml --cov-report=term-missing'
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.11"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ log_cli = 1
 features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
-test = 'pytest --cov=hdx --no-cov-on-fail --junitxml=.tox/test-results.xml --cov-report=xml --cov-report=term-missing'
+test = 'pytest --cov=hdx --cov-config=.config/coveragerc --no-cov-on-fail --junitxml=.tox/test-results.xml --cov-report=xml --cov-report=term-missing'
 
 [[tool.hatch.envs.test.matrix]]
 python = ["3.11"]
@@ -54,25 +54,6 @@ style = [
 fmt = [
   "black --config .config/black.toml {args:.}",
   "ruff --config .config/ruff.toml --fix {args:.}",
-]
-
-[tool.coverage.report]
-omit = [
-    "*/setup.py",
-    "*/python?.?/*",
-    "*/venv/*",
-    "*/site-packages/*",
-    "*/tests/*",
-    "*__init__*"
-]
-exclude_lines = [
-    "pragma: no cover",  # Have to re-enable the standard pragma
-    "def __repr__",  # Don't complain about missing
-    "if self.debug",  # debug-only code
-    "raise AssertionError",  # Don't complain if tests don't hit
-    "raise NotImplementedError",  # defensive assertion code
-    "if 0:",  # Don't complain if non-runnable code
-    "if __name__ == .__main__.:"  # isn't run
 ]
 
 #########################
@@ -149,11 +130,6 @@ packages = ["src/hdx"]
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/hdx/utilities/_version.py"
-
-# Tests
-
-[tool.coverage.paths]
-source = ["src/hdx", "*/site-packages/hdx"]
 
 # Pydoc Markdown - will be moved
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -127,7 +127,7 @@ rfc3986==2.0.0
     # via frictionless
 rich==13.3.5
     # via typer
-ruamel-yaml==0.17.27
+ruamel-yaml==0.17.28
     # via hdx-python-utilities (pyproject.toml)
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,7 @@ click==8.1.3
     # via typer
 colorama==0.4.6
     # via typer
-coverage[toml]==7.2.6
+coverage[toml]==7.2.7
     # via pytest-cov
 decorator==5.1.1
     # via validators
@@ -127,7 +127,7 @@ rfc3986==2.0.0
     # via frictionless
 rich==13.3.5
     # via typer
-ruamel-yaml==0.17.28
+ruamel-yaml==0.17.29
     # via hdx-python-utilities (pyproject.toml)
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -168,7 +168,7 @@ webencodings==0.5.1
     # via html5lib
 xlrd==2.0.1
     # via hdx-python-utilities (pyproject.toml)
-xlsxwriter==3.1.1
+xlsxwriter==3.1.2
     # via tableschema-to-template
 xlwt==1.3.0
     # via hdx-python-utilities (pyproject.toml)


### PR DESCRIPTION
More custom configs. A couple of issues to note:
- I had to separate `black` and `ruff` configurations, because the formats of the files need to be different unfortunately
- I cannot for the life of me figure out if there is a way to use a custom path to `hatch.toml`. There is a `--config` option for `hatch` but it's more for the general configuration file `config.toml`. I can keep searching / experimenting, as this would really pare down `pyrpoject.toml`