### PR TITLE
Fix pytest command line in hatch test scripts

### DIFF
--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -18,8 +18,3 @@ exclude_lines =
     "raise NotImplementedError"  # defensive assertion code
     "if 0:"  # Don't complain if non-runnable code
     "if __name__ == .__main__.:"  # isn't run
-
-[paths]
-source =
-    "src/hdx"
-    "*/site-packages/hdx"

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -1,6 +1,3 @@
-[run]
-relative_files = True
-
 [report]
 omit =
     "*/setup.py"
@@ -21,5 +18,5 @@ exclude_lines =
 
 [paths]
 source =
-    "../src/hdx"
+    "src/hdx"
     "*/site-packages/hdx"

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -1,6 +1,3 @@
-[run]
-relative_files = True
-
 [report]
 omit =
     "*/setup.py"

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -1,3 +1,6 @@
+[run]
+relative_files = True
+
 [report]
 omit =
     "*/setup.py"

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -15,8 +15,3 @@ exclude_lines =
     "raise NotImplementedError"  # defensive assertion code
     "if 0:"  # Don't complain if non-runnable code
     "if __name__ == .__main__.:"  # isn't run
-
-[paths]
-source =
-    "src/hdx"
-    "*/site-packages/hdx"

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -1,10 +1,11 @@
 [run]
 source = src
 
-omit = "_version.py"
+omit = */_version.py
 
 [report]
 exclude_also =
+    from ._version
     def __repr__
     if self.debug:
     if settings.DEBUG

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -1,17 +1,16 @@
-[report]
-omit =
-    "*/setup.py"
-    "*/python?.?/*"
-    "*/venv/*"
-    "*/site-packages/*"
-    "*/tests/*"
-    "*__init__*"
+[run]
+source = src
 
-exclude_lines =
-    "pragma: no cover"  # Have to re-enable the standard pragma
-    "def __repr__"  # Don't complain about missing
-    "if self.debug"  # debug-only code
-    "raise AssertionError"  # Don't complain if tests don't hit
-    "raise NotImplementedError"  # defensive assertion code
-    "if 0:"  # Don't complain if non-runnable code
-    "if __name__ == .__main__.:"  # isn't run
+omit = "_version.py"
+
+[report]
+exclude_also =
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    if TYPE_CHECKING:
+    @(abc\.)?abstractmethod

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -21,5 +21,5 @@ exclude_lines =
 
 [paths]
 source =
-    "src/hdx"
+    "../src/hdx"
     "*/site-packages/hdx"

--- a/.config/coveragerc
+++ b/.config/coveragerc
@@ -15,3 +15,8 @@ exclude_lines =
     "raise NotImplementedError"  # defensive assertion code
     "if 0:"  # Don't complain if non-runnable code
     "if __name__ == .__main__.:"  # isn't run
+
+[paths]
+source =
+    "src/hdx"
+    "*/site-packages/hdx"

--- a/.config/pytest.ini
+++ b/.config/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-pythonpath = "src"
+pythonpath = "../src"
 addopts = "--color=yes"
 log_cli = 1

--- a/.config/pytest.ini
+++ b/.config/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
-pythonpath = "../src"
+pythonpath = ../src
 addopts = "--color=yes"
 log_cli = 1

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -37,7 +37,7 @@ jobs:
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        junit_files: .tox/*.xml
+        junit_files: test-results.xml
     - name: Upload Coverage Results
       uses: codecov/codecov-action@v3
       if: success()

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -32,14 +32,15 @@ jobs:
       if: always()
       run: |
         hatch run lint:style
-    - name: Publish in Coveralls
-      uses: coverallsapp/github-action@v2
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: tests
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         junit_files: test-results.xml
+    - name: Publish in Coveralls
+      uses: coverallsapp/github-action@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: tests
+        format: lcov

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         hatch run lint:style
     - name: Publish in Coveralls
-      uses: AndreMiras/coveralls-python-action@develop
+      uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         flag-name: tests

--- a/.github/workflows/run-python-tests.yml
+++ b/.github/workflows/run-python-tests.yml
@@ -32,12 +32,14 @@ jobs:
       if: always()
       run: |
         hatch run lint:style
+    - name: Publish in Coveralls
+      uses: AndreMiras/coveralls-python-action@develop
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: tests
     - name: Publish Unit Test Results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         junit_files: test-results.xml
-    - name: Upload Coverage Results
-      uses: codecov/codecov-action@v3
-      if: success()

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://github.com/OCHA-DAP/hdx-python-utilities/actions/workflows/run-python-tests.yml/badge.svg)](https://github.com/OCHA-DAP/hdx-python-utilities/actions/workflows/run-python-tests.yml)
-[![Coverage Status](https://codecov.io/gh/OCHA-DAP/hdx-python-utilities/branch/main/graph/badge.svg?token=JpWZc5js4y)](https://codecov.io/gh/OCHA-DAP/hdx-python-utilities)
+[![Coverage Status](https://coveralls.io/repos/github/OCHA-DAP/hdx-python-utilities/badge.svg?branch=main&ts=1)](https://coveralls.io/github/OCHA-DAP/hdx-python-utilities?branch=main)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
 [![Downloads](https://img.shields.io/pypi/dm/hdx-python-utilities.svg)](https://pypistats.org/packages/hdx-python-utilities)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,8 +103,7 @@ features = ["html", "email", "test"]
 test = """
        pytest -c .config/pytest.ini --cov=hdx \
        --cov-config=.config/coveragerc --no-cov-on-fail \
-       --junitxml=test-results.xml --cov-report=xml \
-       --cov-report=term-missing
+       --junitxml=test-results.xml --cov-report=term-missing
        """
 
 [[tool.hatch.envs.test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ features = ["html", "email", "test"]
 [tool.hatch.envs.test.scripts]
 test = """
        pytest -c .config/pytest.ini --rootdir=. --junitxml=test-results.xml \
-       --cov-config=.config/coveragerc --no-cov-on-fail \
+       --cov --cov-config=.config/coveragerc --no-cov-on-fail \
        --cov-report=lcov --cov-report=term-missing
        """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,9 @@ features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
 test = """
-       pytest -c .config/pytest.ini --cov=src/hdx \
+       pytest -c .config/pytest.ini --cov=hdx \
        --cov-config=.config/coveragerc --no-cov-on-fail \
-       --junitxml=test-results.xml --cov-report= \
+       --junitxml=test-results.xml --cov-report=xml \
        --cov-report=term-missing
        """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ features = ["html", "email", "test"]
 [tool.hatch.envs.test.scripts]
 test = """
        pytest -c .config/pytest.ini --rootdir=. \
-       --cov=hdx --cov-config=.config/coveragerc --no-cov-on-fail \
+       --cov=. --cov-config=.config/coveragerc --no-cov-on-fail \
        --junitxml=test-results.xml --cov-report=term-missing
        """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,9 @@ features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
 test = """
-       pytest -c .config/pytest.ini --rootdir=. \
+       pytest -c .config/pytest.ini --rootdir=. --junitxml=test-results.xml \
        --cov=. --cov-config=.config/coveragerc --no-cov-on-fail \
-       --junitxml=test-results.xml --cov-report=term-missing
+       --cov-report=lcov --cov-report=term-missing
        """
 
 [[tool.hatch.envs.test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ features = ["html", "email", "test"]
 test = """
        pytest -c .config/pytest.ini --cov=hdx \
        --cov-config=.config/coveragerc --no-cov-on-fail \
-       --junitxml=test-results.xml --cov-report=xml \
+       --junitxml=test-results.xml --cov-report= \
        --cov-report=term-missing
        """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
 test = """
-       pytest -c .config/pytest.ini --cov=hdx \
+       pytest -c .config/pytest.ini --cov=src/hdx \
        --cov-config=.config/coveragerc --no-cov-on-fail \
        --junitxml=test-results.xml --cov-report=term-missing
        """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
 test = """
-       pytest -c .config/pytest.ini --cov=hdx \
+       pytest -c .config/pytest.ini --cov=src/hdx \
        --cov-config=.config/coveragerc --no-cov-on-fail \
        --junitxml=test-results.xml --cov-report= \
        --cov-report=term-missing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ features = ["html", "email", "test"]
 [tool.hatch.envs.test.scripts]
 test = """
        pytest -c .config/pytest.ini --rootdir=. --junitxml=test-results.xml \
-       --cov=src --cov-config=.config/coveragerc --no-cov-on-fail \
+       --cov-config=.config/coveragerc --no-cov-on-fail \
        --cov-report=lcov --cov-report=term-missing
        """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,8 +101,8 @@ features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
 test = """
-       pytest -c .config/pytest.ini --cov=src/hdx \
-       --cov-config=.config/coveragerc --no-cov-on-fail \
+       pytest -c .config/pytest.ini --rootdir=. \
+       --cov=hdx --cov-config=.config/coveragerc --no-cov-on-fail \
        --junitxml=test-results.xml --cov-report=term-missing
        """
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,10 +101,10 @@ features = ["html", "email", "test"]
 
 [tool.hatch.envs.test.scripts]
 test = """
-       pytest -c .config/pytest.ini --cov=hdx
-       --cov-config=.config/coveragerc --no-cov-on-fail
-       --junitxml=.tox/test-results.xml --cov-report=xml
-       --cov-report=term-missing"
+       pytest -c .config/pytest.ini --cov=hdx \
+       --cov-config=.config/coveragerc --no-cov-on-fail \
+       --junitxml=test-results.xml --cov-report=xml \
+       --cov-report=term-missing
        """
 
 [[tool.hatch.envs.test.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ features = ["html", "email", "test"]
 [tool.hatch.envs.test.scripts]
 test = """
        pytest -c .config/pytest.ini --rootdir=. --junitxml=test-results.xml \
-       --cov=. --cov-config=.config/coveragerc --no-cov-on-fail \
+       --cov=src --cov-config=.config/coveragerc --no-cov-on-fail \
        --cov-report=lcov --cov-report=term-missing
        """
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,7 +71,7 @@ markdown-it-py==2.2.0
     # via rich
 marko==1.3.0
     # via frictionless
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mdurl==0.1.2
     # via markdown-it-py
@@ -125,9 +125,9 @@ requests-file==1.5.1
     # via hdx-python-utilities (pyproject.toml)
 rfc3986==2.0.0
     # via frictionless
-rich==13.3.5
+rich==13.4.1
     # via typer
-ruamel-yaml==0.17.29
+ruamel-yaml==0.17.31
     # via hdx-python-utilities (pyproject.toml)
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
@@ -153,7 +153,7 @@ text-unidecode==1.3
     # via python-slugify
 typer[all]==0.9.0
     # via frictionless
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   frictionless
     #   pydantic


### PR DESCRIPTION
This fixes the tests failing to run in GitHub Actions. Does it looks ok to you @turnerm ?

What I don't get is that when I run locally `hatch run test:test`, it fails with:
```
tests/hdx/conftest.py:7: in <module>
    from hdx.utilities.downloader import Download
E   ModuleNotFoundError: No module named 'hdx'
```

Does it work locally for you?