### PR TITLE
GH22 Add encoding to compare file functions

### DIFF
--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -1,14 +1,17 @@
 line-length = 79
 exclude = ["_version.py"]
-lint.ignore = [
-    "E501" # Line too long
-]
+
+[lint]
 # List of rules: https://docs.astral.sh/ruff/rules/
-lint.select = [
+select = [
   "E",   # pycodestyle - default
   "F",   # pyflakes - default
   "I"    # isort
 ]
+ignore = [
+    "E501" # Line too long
+]
+
 
 [lint.isort]
 known-local-folder = ["hdx"]

--- a/.config/ruff.toml
+++ b/.config/ruff.toml
@@ -1,14 +1,14 @@
 line-length = 79
 exclude = ["_version.py"]
-ignore = [
+lint.ignore = [
     "E501" # Line too long
 ]
 # List of rules: https://docs.astral.sh/ruff/rules/
-select = [
+lint.select = [
   "E",   # pycodestyle - default
   "F",   # pyflakes - default
   "I"    # isort
 ]
 
-[isort]
+[lint.isort]
 known-local-folder = ["hdx"]

--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,5 @@ ENV/
 
 # hatch-vcs
 _version.py
+
+.vscode/settings.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,11 @@ charset-normalizer==3.3.2
 click==8.1.7
     # via typer
 colorama==0.4.6
-    # via typer
+    # via
+    #   click
+    #   loguru
+    #   pytest
+    #   typer
 coverage[toml]==7.4.1
     # via
     #   coverage
@@ -172,6 +176,8 @@ virtualenv==20.25.0
     # via pre-commit
 webencodings==0.5.1
     # via html5lib
+win32-setctime==1.1.0
+    # via loguru
 xlrd==2.0.1
     # via hdx-python-utilities (pyproject.toml)
 xlsxwriter==3.1.9

--- a/src/hdx/utilities/compare.py
+++ b/src/hdx/utilities/compare.py
@@ -4,7 +4,9 @@ from os import linesep
 from typing import List
 
 
-def compare_files(path1: str, path2: str, encoding: str = "utf-8") -> List[str]:
+def compare_files(
+    path1: str, path2: str, encoding: str = "utf-8"
+) -> List[str]:
     """Returns the delta between two files using -, ?, + format excluding lines
     that are the same.
 

--- a/src/hdx/utilities/compare.py
+++ b/src/hdx/utilities/compare.py
@@ -4,7 +4,7 @@ from os import linesep
 from typing import List
 
 
-def compare_files(path1: str, path2: str) -> List[str]:
+def compare_files(path1: str, path2: str, encoding: str = "utf-8") -> List[str]:
     """Returns the delta between two files using -, ?, + format excluding lines
     that are the same.
 
@@ -16,12 +16,13 @@ def compare_files(path1: str, path2: str) -> List[str]:
         List[str]: Delta between the two files
     """
     diff = difflib.ndiff(
-        open(path1).read().splitlines(), open(path2).read().splitlines()
+        open(path1, encoding=encoding).read().splitlines(),
+        open(path2, encoding=encoding).read().splitlines(),
     )
     return [x for x in diff if x[0] in ["-", "+", "?"]]
 
 
-def assert_files_same(path1: str, path2: str) -> None:
+def assert_files_same(path1: str, path2: str, encoding: str = "utf-8") -> None:
     """Asserts that two files are the same and returns delta using.
 
     -, ?, + format if not
@@ -33,5 +34,5 @@ def assert_files_same(path1: str, path2: str) -> None:
     Returns:
         None
     """
-    difflines = compare_files(path1, path2)
+    difflines = compare_files(path1, path2, encoding)
     assert len(difflines) == 0, linesep.join([linesep] + difflines)

--- a/src/hdx/utilities/loader.py
+++ b/src/hdx/utilities/loader.py
@@ -32,14 +32,14 @@ def load_text(
         replace_newlines (Optional[str]): String with which to replace newlines. Defaults to None (don't replace). (deprecated 2024-02-07)
         replace_line_separators (Optional[str]): String with which to replace newlines. Defaults to None (don't replace).
         loaderror_if_empty (bool): Whether to raise LoadError if file is empty. Default to True.
-        default_line_separator (str): line separator to be replaced if replace_newlines is True
+        default_line_separator (str): line separator to be replaced if replace_line_separators is not None
 
     Returns:
         str: String contents of file
     """
     if replace_newlines is not None:
         warn(
-            "Keyword argument 'replace_newlines' to 'load_text' is deprecated "
+            "Keyword argument 'replace_newlines' to 'load_text' is deprecated on 2024-02-08 "
             "in favour of 'replace_line_separators'",
             DeprecationWarning,
             stacklevel=2,

--- a/src/hdx/utilities/loader.py
+++ b/src/hdx/utilities/loader.py
@@ -33,10 +33,11 @@ def load_text(
     Returns:
         str: String contents of file
     """
+    linesep_ = "\n"
     with open(path, encoding=encoding) as f:
         string = f.read()
         if replace_newlines is not None:
-            string = string.replace(linesep, replace_newlines)
+            string = string.replace(linesep_, replace_newlines)
         if strip:
             string = string.strip()
     if not string:
@@ -108,9 +109,7 @@ def load_and_merge_yaml(
         Dict: Dictionary of merged YAML files
     """
     configs = [
-        load_yaml(
-            path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
-        )
+        load_yaml(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
         for path in paths
     ]
     return merge_dictionaries(configs)
@@ -133,9 +132,7 @@ def load_and_merge_json(
         Dict: Dictionary of merged JSON files
     """
     configs = [
-        load_json(
-            path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
-        )
+        load_json(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
         for path in paths
     ]
     return merge_dictionaries(configs)
@@ -158,9 +155,7 @@ def load_yaml_into_existing_dict(
     Returns:
         Dict: YAML file merged into dictionary
     """
-    yamldict = load_yaml(
-        path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
-    )
+    yamldict = load_yaml(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
     return merge_two_dictionaries(data, yamldict)
 
 
@@ -181,7 +176,5 @@ def load_json_into_existing_dict(
     Returns:
         dict: JSON file merged into dictionary
     """
-    jsondict = load_json(
-        path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
-    )
+    jsondict = load_json(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
     return merge_two_dictionaries(data, jsondict)

--- a/src/hdx/utilities/loader.py
+++ b/src/hdx/utilities/loader.py
@@ -1,7 +1,6 @@
 """Loading utilities for YAML, JSON etc."""
 
 import json
-from os import linesep
 from typing import Any, Dict, Optional
 
 from ruamel.yaml import YAML
@@ -109,7 +108,9 @@ def load_and_merge_yaml(
         Dict: Dictionary of merged YAML files
     """
     configs = [
-        load_yaml(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
+        load_yaml(
+            path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
+        )
         for path in paths
     ]
     return merge_dictionaries(configs)
@@ -132,7 +133,9 @@ def load_and_merge_json(
         Dict: Dictionary of merged JSON files
     """
     configs = [
-        load_json(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
+        load_json(
+            path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
+        )
         for path in paths
     ]
     return merge_dictionaries(configs)
@@ -155,7 +158,9 @@ def load_yaml_into_existing_dict(
     Returns:
         Dict: YAML file merged into dictionary
     """
-    yamldict = load_yaml(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
+    yamldict = load_yaml(
+        path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
+    )
     return merge_two_dictionaries(data, yamldict)
 
 
@@ -176,5 +181,7 @@ def load_json_into_existing_dict(
     Returns:
         dict: JSON file merged into dictionary
     """
-    jsondict = load_json(path, encoding=encoding, loaderror_if_empty=loaderror_if_empty)
+    jsondict = load_json(
+        path, encoding=encoding, loaderror_if_empty=loaderror_if_empty
+    )
     return merge_two_dictionaries(data, jsondict)

--- a/src/hdx/utilities/loader.py
+++ b/src/hdx/utilities/loader.py
@@ -2,6 +2,7 @@
 
 import json
 from typing import Any, Dict, Optional
+from warnings import warn
 
 from ruamel.yaml import YAML
 
@@ -18,7 +19,9 @@ def load_text(
     encoding: str = "utf-8",
     strip: bool = False,
     replace_newlines: Optional[str] = None,
+    replace_line_separators: Optional[str] = None,
     loaderror_if_empty: bool = True,
+    default_line_separator: str = "\n",
 ) -> str:
     """Load file into a string removing newlines.
 
@@ -26,17 +29,28 @@ def load_text(
         path (str): Path to file
         encoding (str): Encoding of file. Defaults to utf-8.
         strip (bool): Whether to strip whitespace from start and end. Defaults to False.
-        replace_newlines (Optional[str]): String with which tp replace newlines. Defaults to None (don't replace).
+        replace_newlines (Optional[str]): String with which to replace newlines. Defaults to None (don't replace). (deprecated 2024-02-07)
+        replace_line_separators (Optional[str]): String with which to replace newlines. Defaults to None (don't replace).
         loaderror_if_empty (bool): Whether to raise LoadError if file is empty. Default to True.
+        default_line_separator (str): line separator to be replaced if replace_newlines is True
 
     Returns:
         str: String contents of file
     """
-    linesep_ = "\n"
+    if replace_newlines is not None:
+        warn(
+            "Keyword argument 'replace_newlines' to 'load_text' is deprecated "
+            "in favour of 'replace_line_separators'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        replace_line_separators = replace_newlines
     with open(path, encoding=encoding) as f:
         string = f.read()
-        if replace_newlines is not None:
-            string = string.replace(linesep_, replace_newlines)
+        if replace_line_separators is not None:
+            string = string.replace(
+                default_line_separator, replace_line_separators
+            )
         if strip:
             string = string.strip()
     if not string:

--- a/tests/fixtures/compare/test_csv_processing.csv
+++ b/tests/fixtures/compare/test_csv_processing.csv
@@ -1,4 +1,4 @@
-la1    ,ha1    ,ba1    ,ma1
+la1    ,hä1    ,ba1    ,ma1
 header1,header2,header3,header4
 coal   ,3      ,7.4    ,'needed'
 gas    ,2      ,6.5    ,'n/a'

--- a/tests/fixtures/compare/test_csv_processing2.csv
+++ b/tests/fixtures/compare/test_csv_processing2.csv
@@ -1,4 +1,4 @@
-la1    ,ha1    ,ba1    ,ma1
+la1    ,hä1    ,ba1    ,ma1
 header1,header2,header3,header4
 coal   ,1      ,7.4    ,'notneeded'
 gas    ,2      ,6.5    ,'n/a'

--- a/tests/hdx/utilities/test_compare.py
+++ b/tests/hdx/utilities/test_compare.py
@@ -1,5 +1,6 @@
 """Compare Utility Tests"""
 from os.path import join
+
 import pytest
 
 from hdx.utilities.compare import assert_files_same, compare_files

--- a/tests/hdx/utilities/test_compare.py
+++ b/tests/hdx/utilities/test_compare.py
@@ -16,7 +16,7 @@ class TestCompare:
         return join(fixturesfolder, "compare", "test_csv_processing2.csv")
 
     def test_compare_files(self, testfile1, testfile2):
-        result = compare_files(testfile1, testfile2)
+        result = compare_files(testfile1, testfile2, encoding="utf-8")
         assert result == [
             "- coal   ,3      ,7.4    ,'needed'",
             "?         ^\n",

--- a/tests/hdx/utilities/test_compare.py
+++ b/tests/hdx/utilities/test_compare.py
@@ -1,6 +1,5 @@
 """Compare Utility Tests"""
 from os.path import join
-
 import pytest
 
 from hdx.utilities.compare import assert_files_same, compare_files

--- a/tests/hdx/utilities/test_dateparse.py
+++ b/tests/hdx/utilities/test_dateparse.py
@@ -1,6 +1,5 @@
 """Date Parse Utility Tests"""
 from datetime import datetime, timedelta, timezone
-
 import pytest
 from dateutil.parser import ParserError
 

--- a/tests/hdx/utilities/test_dateparse.py
+++ b/tests/hdx/utilities/test_dateparse.py
@@ -2,7 +2,6 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
-
 from dateutil.parser import ParserError
 
 from hdx.utilities.dateparse import (

--- a/tests/hdx/utilities/test_dateparse.py
+++ b/tests/hdx/utilities/test_dateparse.py
@@ -1,6 +1,8 @@
 """Date Parse Utility Tests"""
 from datetime import datetime, timedelta, timezone
+
 import pytest
+
 from dateutil.parser import ParserError
 
 from hdx.utilities.dateparse import (

--- a/tests/hdx/utilities/test_downloader.py
+++ b/tests/hdx/utilities/test_downloader.py
@@ -403,7 +403,7 @@ class TestDownloader:
                 filename=filename,
             )
             fpath = abspath(f)
-            with open(fpath) as fi:
+            with open(fpath, encoding="utf-8") as fi:
                 text = fi.read()
                 assert '"id": "10"' in text
                 assert '"lala": "a"' in text
@@ -419,7 +419,7 @@ class TestDownloader:
                 filename=filename,
             )
             fpath = abspath(f)
-            with open(fpath) as fi:
+            with open(fpath, encoding="utf-8") as fi:
                 text = fi.read()
                 assert '"id": "3"' in text
                 assert '"lala": "b"' in text

--- a/tests/hdx/utilities/test_loader.py
+++ b/tests/hdx/utilities/test_loader.py
@@ -172,7 +172,7 @@ test"""
             assert result == TestLoader.text
             result = load_text(text_file, strip=True)
             assert result == TestLoader.expected_text_strip
-            result = load_text(text_file, replace_newlines=" ")
+            result = load_text(text_file, replace_line_separators=" ")
             assert result == TestLoader.expected_text_newlines_to_spaces
             with pytest.raises(IOError):
                 load_text(join(tmpdir, "NOTEXIST.txt"))

--- a/tests/hdx/utilities/test_path.py
+++ b/tests/hdx/utilities/test_path.py
@@ -128,9 +128,7 @@ class TestPath:
         ]
         expected_batch_file = join(expected_dir, "batch.txt")
         result = list()
-        for info, nextdict in progress_storing_tempdir(
-            tempfolder, iterator, "iso3"
-        ):
+        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
             assert info["folder"] == expected_dir
             expected_batch = load_text(expected_batch_file, strip=True)
             result.append(nextdict)
@@ -140,9 +138,7 @@ class TestPath:
 
         monkeypatch.setenv("WHERETOSTART", "iso3=SDN")
         result = list()
-        for info, nextdict in progress_storing_tempdir(
-            tempfolder, iterator, "iso3"
-        ):
+        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             expected_batch = load_text(expected_batch_file, strip=True)
@@ -163,9 +159,7 @@ class TestPath:
             pass
         assert exists(expected_dir) is True
         result = list()
-        for info, nextdict in progress_storing_tempdir(
-            tempfolder, iterator, "iso3"
-        ):
+        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             assert info["batch"] == start_batch
@@ -185,9 +179,7 @@ class TestPath:
         assert exists(expected_dir) is True
         monkeypatch.setenv("WHERETOSTART", "RESET")
         result = list()
-        for info, nextdict in progress_storing_tempdir(
-            tempfolder, iterator, "iso3"
-        ):
+        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             assert info["batch"] != start_batch
@@ -208,9 +200,7 @@ class TestPath:
         assert exists(expected_dir) is True
         monkeypatch.setenv("WHERETOSTART", "iso3=SDN")
         result = list()
-        for info, nextdict in progress_storing_tempdir(
-            tempfolder, iterator, "iso3"
-        ):
+        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             assert info["batch"] == start_batch
@@ -272,7 +262,7 @@ class TestPath:
             (
                 0,
                 {
-                    "folder": "/tmp/gaga/0",
+                    "folder": join(expected_dir, "0"),
                     "batch": "1234",
                     "progress": "emergency_id=911",
                 },
@@ -281,7 +271,7 @@ class TestPath:
             (
                 1,
                 {
-                    "folder": "/tmp/gaga/1",
+                    "folder": join(expected_dir, "1"),
                     "batch": "1234",
                     "progress": "iso3=AFG",
                 },
@@ -290,7 +280,7 @@ class TestPath:
             (
                 1,
                 {
-                    "folder": "/tmp/gaga/1",
+                    "folder": join(expected_dir, "1"),
                     "batch": "1234",
                     "progress": "iso3=SDN",
                 },
@@ -299,7 +289,7 @@ class TestPath:
             (
                 1,
                 {
-                    "folder": "/tmp/gaga/1",
+                    "folder": join(expected_dir, "1"),
                     "batch": "1234",
                     "progress": "iso3=YEM",
                 },
@@ -308,7 +298,7 @@ class TestPath:
             (
                 1,
                 {
-                    "folder": "/tmp/gaga/1",
+                    "folder": join(expected_dir, "1"),
                     "batch": "1234",
                     "progress": "iso3=ZAM",
                 },
@@ -395,9 +385,7 @@ class TestPath:
         rmtree(expected_dir, ignore_errors=True)
 
     def test_get_filename_extension_from_url(self, fixtureurl):
-        filename = get_filename_from_url(
-            "http://test.com/test.csv", second_last=True
-        )
+        filename = get_filename_from_url("http://test.com/test.csv", second_last=True)
         assert filename == "test.csv"
         filename = get_filename_from_url("http://test.com/test/test.csv", True)
         assert filename == "test_test.csv"

--- a/tests/hdx/utilities/test_path.py
+++ b/tests/hdx/utilities/test_path.py
@@ -128,7 +128,9 @@ class TestPath:
         ]
         expected_batch_file = join(expected_dir, "batch.txt")
         result = list()
-        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
+        for info, nextdict in progress_storing_tempdir(
+            tempfolder, iterator, "iso3"
+        ):
             assert info["folder"] == expected_dir
             expected_batch = load_text(expected_batch_file, strip=True)
             result.append(nextdict)
@@ -138,7 +140,9 @@ class TestPath:
 
         monkeypatch.setenv("WHERETOSTART", "iso3=SDN")
         result = list()
-        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
+        for info, nextdict in progress_storing_tempdir(
+            tempfolder, iterator, "iso3"
+        ):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             expected_batch = load_text(expected_batch_file, strip=True)
@@ -159,7 +163,9 @@ class TestPath:
             pass
         assert exists(expected_dir) is True
         result = list()
-        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
+        for info, nextdict in progress_storing_tempdir(
+            tempfolder, iterator, "iso3"
+        ):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             assert info["batch"] == start_batch
@@ -179,7 +185,9 @@ class TestPath:
         assert exists(expected_dir) is True
         monkeypatch.setenv("WHERETOSTART", "RESET")
         result = list()
-        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
+        for info, nextdict in progress_storing_tempdir(
+            tempfolder, iterator, "iso3"
+        ):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             assert info["batch"] != start_batch
@@ -200,7 +208,9 @@ class TestPath:
         assert exists(expected_dir) is True
         monkeypatch.setenv("WHERETOSTART", "iso3=SDN")
         result = list()
-        for info, nextdict in progress_storing_tempdir(tempfolder, iterator, "iso3"):
+        for info, nextdict in progress_storing_tempdir(
+            tempfolder, iterator, "iso3"
+        ):
             assert exists(info["folder"]) is True
             assert info["folder"] == expected_dir
             assert info["batch"] == start_batch
@@ -385,7 +395,9 @@ class TestPath:
         rmtree(expected_dir, ignore_errors=True)
 
     def test_get_filename_extension_from_url(self, fixtureurl):
-        filename = get_filename_from_url("http://test.com/test.csv", second_last=True)
+        filename = get_filename_from_url(
+            "http://test.com/test.csv", second_last=True
+        )
         assert filename == "test.csv"
         filename = get_filename_from_url("http://test.com/test/test.csv", True)
         assert filename == "test_test.csv"


### PR DESCRIPTION
This PR adds an encoding keyword argument to the compare files function. It also fixes some instances where tests failed on Windows.

There is not a test for the new compare files functionality since this would be challenging to arrange. 

Issue is described in #22 