### PR TITLE
Update the xlsx2csv dependency to accept >= 0.8.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "ratelimit",
     "requests-file",
     "ruamel.yaml",
-    "xlsx2csv==0.8.4",
+    "xlsx2csv>=0.8.4",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -589,7 +589,7 @@ requires-dist = [
     { name = "tableschema-to-template", specifier = ">=0.0.13" },
     { name = "typing-extensions" },
     { name = "xlrd", specifier = ">=2.0.1" },
-    { name = "xlsx2csv", specifier = "==0.8.4" },
+    { name = "xlsx2csv", specifier = ">=0.8.4" },
     { name = "xlwt", specifier = ">=1.3.0" },
 ]
 provides-extras = ["diff", "docs", "email", "html"]


### PR DESCRIPTION
- There are newer versions with good bugfixes that are backwards compatible, and as a library, users should be allowed to use the newer versions if needed and not be limited to the old version.